### PR TITLE
add package name so can be installed via npm/yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "linearicons-scss",
+  "version": "1.0.0",
   "private": true,
   "devDependencies": {
     "gulp": "^3.8.8"


### PR DESCRIPTION
You should include the package name so the project can be installed via npm/yarn (i.e. `npm install --save https://github.com/ned-kelly/linearicons-scss.git`